### PR TITLE
Fix: 베포 시 severUrl 공백으로 수정

### DIFF
--- a/src/services/fetchDashboard.jsx
+++ b/src/services/fetchDashboard.jsx
@@ -1,4 +1,4 @@
-const serverUrl = import.meta.env.VITE_APP_SERVER_URL;
+const serverUrl = import.meta.env.VITE_APP_SERVER_URL || "";
 
 export const getMyIngredients = async () => {
   const endpoint = `${serverUrl}/api/food/my_foods`;

--- a/src/services/fetchIngredient.jsx
+++ b/src/services/fetchIngredient.jsx
@@ -1,4 +1,4 @@
-const serverUrl = import.meta.env.VITE_APP_SERVER_URL;
+const serverUrl = import.meta.env.VITE_APP_SERVER_URL || "";
 
 const getIngredientListByName = async (keyword) => {
   const endpoint = `${serverUrl}/api/food/search?food=${keyword}`;

--- a/src/services/fetchRecipe.jsx
+++ b/src/services/fetchRecipe.jsx
@@ -1,4 +1,4 @@
-const serverUrl = import.meta.env.VITE_APP_SERVER_URL;
+const serverUrl = import.meta.env.VITE_APP_SERVER_URL || "";
 // 레시피 조회
 
 export const getRecipe = async (recipeId) => {

--- a/src/services/fetchUserRecipe.jsx
+++ b/src/services/fetchUserRecipe.jsx
@@ -1,4 +1,4 @@
-const serverUrl = import.meta.env.VITE_APP_SERVER_URL;
+const serverUrl = import.meta.env.VITE_APP_SERVER_URL || "";
 
 // 레시피 북마크
 

--- a/src/utils/fetchData.jsx
+++ b/src/utils/fetchData.jsx
@@ -1,6 +1,4 @@
-import parseRecipe from "./parseRecipe.jsx";
-
-const serverUrl = import.meta.env.VITE_APP_SERVER_URL;
+const serverUrl = import.meta.env.VITE_APP_SERVER_URL || "";
 
 export const login = async () => {
   const path = "/api/oauth2/authorization/kakao";

--- a/src/utils/fetchIngredient.jsx
+++ b/src/utils/fetchIngredient.jsx
@@ -1,4 +1,4 @@
-const serverUrl = import.meta.env.VITE_APP_SERVER_URL;
+const serverUrl = import.meta.env.VITE_APP_SERVER_URL || "";
 
 export const fetchIngredientRegister = async (ingredients) => {
   const path = "/api/food";

--- a/src/utils/fetchUserLogOut.jsx
+++ b/src/utils/fetchUserLogOut.jsx
@@ -1,4 +1,4 @@
-const serverUrl = import.meta.env.VITE_APP_SERVER_URL;
+const serverUrl = import.meta.env.VITE_APP_SERVER_URL || "";
 
 export const fetchUserLogOut = async () => {
   const path = "/api/logout";


### PR DESCRIPTION
도메인이 같을 경우 환경변수로 server url을 줄 이유가 없음